### PR TITLE
I make the response handle the client_max_body_limit in the right way

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -1,6 +1,6 @@
 server {
     listen 8000;
-    server_name example.com;
+    server_name localhost;
     index index.html;
     allowed_method GET POST DELETE;
     error_page 404 ./conf-4x04.html;

--- a/sources/parsers/default/config.cpp
+++ b/sources/parsers/default/config.cpp
@@ -4,7 +4,7 @@ Config::Config()
 {
     listen_port          = 0;
     server_name          = "";
-    client_max_body_size = 0;
+    client_max_body_size = -1;
     index                = std::vector<std::string>();
     allowed_method       = std::vector<std::string>();
     error_page           = std::vector<std::string>();
@@ -18,7 +18,7 @@ Config::Config( std::vector<std::string>::iterator &it,
 {
     listen_port          = 0;
     server_name          = "";
-    client_max_body_size = 0;
+    client_max_body_size = -1;
     index                = std::vector<std::string>();
     allowed_method       = std::vector<std::string>();
     error_page           = std::vector<std::string>();

--- a/sources/response/response.cpp
+++ b/sources/response/response.cpp
@@ -45,6 +45,13 @@ ft::Response::Response( Request request, Config server_conf ) :
         return; 
     }
 
+   if (server_conf.client_max_body_size != -1 && static_cast<int>(request.body.size()) > static_cast<int>(server_conf.client_max_body_size)) {
+        setStatusCode("413 Payload Too Large");
+        setContentType("text/plain");
+        setBody("Request body size exceeds the limit.");
+        return;
+    }
+
     if ( request.uri != "/" && request.uri != ""
          && isLocation( request.uri ) ) {
         if ( !isValidMethod( request.method, using_route.allow_methods ) ) {
@@ -111,11 +118,8 @@ std::string ft::Response::makeResponse()
         response.append( "\r\n" );
     }
 
-    // Check body limit and truncate if necessary
-    if ( server_conf.client_max_body_size
-         && getContentLength() > server_conf.client_max_body_size ) {
-        body = body.substr( 0, server_conf.client_max_body_size );
-    }
+   
+
 
     response.append( body );
 

--- a/sources/server/server.cpp
+++ b/sources/server/server.cpp
@@ -149,7 +149,7 @@ void Server::accept_connections()
                     logger.error( "Error accepting connection" );
                     close( server_socket );
                 } else {
-                    read_request_data( connection_socket, 1024 );
+                    read_request_data( connection_socket, 1024);
                     Request request( requests[connection_socket].c_str() );
                     request.display();
                     Config server_conf = this->servers_conf[i];


### PR DESCRIPTION
We had done the client_max_body_size the wrong way. Previously, we were limiting the response body. However, we should have been limiting the client's body. This actually makes more sense from a security perspective since we can prevent the client from sending something larger than necessary in the body.

Now it is working. You can test this with: curl -v -X DELETE -d "data123456" http://localhost:8000/ since our POST isnt working very well. 